### PR TITLE
fix: title not always contains the id

### DIFF
--- a/src/lib/episodes.tsx
+++ b/src/lib/episodes.tsx
@@ -14,8 +14,15 @@ export const getEpisodesFromRSSFeed = async () => {
 
   const jsonObj = parser.parse(xml);
   const episodes = jsonObj.rss.channel.item.map((item: EpisodeType) => {
-    item.id = item.title.split(':')[0];
-    item.titleShort = item.title.split(':')[1].trim();
+    const titleSplit = item.title.split(':');
+
+    if (titleSplit.length > 1) {
+      item.id = titleSplit[0];
+      item.titleShort = titleSplit[1].trim();
+    } else {
+      item.id = "GAG";
+      item.titleShort = item.title;
+    }
 
     const yearInDescription =
       item.description.match(/[0-9][0-9][0-9][0-9]/)?.[0];


### PR DESCRIPTION
Hi! I noticed that the site is currently broken. The reason seems to be that there is at least one entry in the RSS feed where the episode ID (GAGXYZ) is not part of an item's title. I added an if statement to handle that. For now, I use the static id GAG in that case, but I don't know if that has any side effects (e.g., it could be that the app requires the ID's to be unique, I'm not sure...). At least locally it seems to be working fine with the change. Thanks for the project!